### PR TITLE
Fix PHP 8.4+ implicit-nullable deprecation in U2F Error constructor

### DIFF
--- a/includes/Yubico/U2F.php
+++ b/includes/Yubico/U2F.php
@@ -501,7 +501,7 @@ class Error extends \Exception
      * @param int $code
      * @param \Exception|null $previous
      */
-    public function __construct($message, $code, \Exception $previous = null) {
+    public function __construct($message, $code, ?\Exception $previous = null) {
         parent::__construct($message, $code, $previous);
     }
 }


### PR DESCRIPTION
## Summary

`includes/Yubico/U2F.php:504` declares `\Exception $previous = null` — an implicit-nullable parameter, deprecated in PHP 8.4 and 8.5. This one-line change adds the explicit `?` to silence the deprecation notice. The docblock already says `@param \Exception|null $previous`, so behaviour is unchanged.

## Repro

Under PHP 8.5, loading any code path that touches `U2F.php` emits:

```
Deprecated: u2flib_server\Error::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in .../vendor/humanmade/two-factor/includes/Yubico/U2F.php on line 504
```

In Altis this fires on every WP request inside the local stack on the PHP 8.5 image.

## Context

Targeting `force-2fa` because that's the branch Altis ships from (currently pinned at `^0.3.3` via `altis/security`). 